### PR TITLE
Fix html entities in text (eg. < turns into &lt;)

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -16,9 +16,11 @@ def mirrorText(oTweet):
     bruh = ' '.join(word for word in oTweet.split() if word[0]!='@')                            #remove @s (if the user replies to someone the tweet is "@user 'tweet'" and without this your tweet will include the "resu@" at the end)
     bruh = ' '.join([term for term in bruh.split() if not term.startswith("https://t.co/")])    #remove links of images, videos and quote retweets
     newTweet = str(bruh[::-1])                                                                       #mirror the rest of the text
-
-
-
+    html_entities = {"&lt;": "<", "&gt;": ">", "&amp;": "&", "&quot;": "\"", "&apos;": "\'", "&cent;": "¢", "&pound;": "£", "&yen;": "¥", "&euro;": "€", "&copy;": "©", "&reg;": "®"}
+    for entity in html_entities:
+        if entity in bruh:
+            bruh = bruh.replace(entity, html_entities.get(entity))
+    newTweet = str(bruh[::-1])  
     return newTweet
 
 checkNewTweet = api.user_timeline(screen_name=username,since_id = str(lastID))

--- a/Bot.py
+++ b/Bot.py
@@ -14,8 +14,7 @@ i = 0
 def mirrorText(oTweet):
 
     bruh = ' '.join(word for word in oTweet.split() if word[0]!='@')                            #remove @s (if the user replies to someone the tweet is "@user 'tweet'" and without this your tweet will include the "resu@" at the end)
-    bruh = ' '.join([term for term in bruh.split() if not term.startswith("https://t.co/")])    #remove links of images, videos and quote retweets
-    newTweet = str(bruh[::-1])                                                                       #mirror the rest of the text
+    bruh = ' '.join([term for term in bruh.split() if not term.startswith("https://t.co/")])    #remove links of images, videos and quote retweets                                                                  #mirror the rest of the text
     html_entities = {"&lt;": "<", "&gt;": ">", "&amp;": "&", "&quot;": "\"", "&apos;": "\'", "&cent;": "¢", "&pound;": "£", "&yen;": "¥", "&euro;": "€", "&copy;": "©", "&reg;": "®"}
     for entity in html_entities:
         if entity in bruh:


### PR DESCRIPTION
Characters get replaced with entity names referenced in https://www.w3schools.com/html/html_entities.asp - this fixes that, it goes through all the entity names and checks if it's in the text, if it is, it pulls what the actual character was supposed to be and puts it in the text